### PR TITLE
Update repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# cg-sandbox 
+# purge-sandboxes 
 
-[![Code Climate](https://codeclimate.com/github/18F/cg-sandbox/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-sandbox)
+[![Code Climate](https://codeclimate.com/github/18F/purge-sandboxes/badges/gpa.svg)](https://codeclimate.com/github/18F/purge-sandboxes)
 
 Purges cloud.gov sandbox resources.
 
-See https://github.com/18F/cg-sandbox-bot for the code that automatically creates sandbox spaces for whitelisted users.
+See https://github.com/18F/purge-sandboxes-bot for the code that automatically creates sandbox spaces for whitelisted users.
 
 ## Contributing 
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# purge-sandboxes 
-
-[![Code Climate](https://codeclimate.com/github/18F/purge-sandboxes/badges/gpa.svg)](https://codeclimate.com/github/18F/purge-sandboxes)
+# purge-sandboxes
 
 Purges cloud.gov sandbox resources.
 
-See https://github.com/18F/purge-sandboxes-bot for the code that automatically creates sandbox spaces for whitelisted users.
+See <https://github.com/cloud-gov/cg-sandbox-bot> for the code that automatically creates sandbox spaces for whitelisted users.
 
-## Contributing 
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -121,7 +121,7 @@ resources:
   type: git
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
-    uri: https://github.com/cloud-gov/cg-sandbox
+    uri: https://github.com/cloud-gov/purge-sandboxes
     branch: main
 
 - name: schedule

--- a/ci/purge.sh
+++ b/ci/purge.sh
@@ -5,7 +5,7 @@ set -e
 export GOPATH=$(pwd)/gopath
 export PATH=$PATH:$GOPATH/bin
 
-cd gopath/src/github.com/18F/purge-sandboxes
+cd gopath/src/github.com/cloud-gov/purge-sandboxes
 
 cd cmd/purge
 

--- a/ci/purge.sh
+++ b/ci/purge.sh
@@ -5,7 +5,7 @@ set -e
 export GOPATH=$(pwd)/gopath
 export PATH=$PATH:$GOPATH/bin
 
-cd gopath/src/github.com/18F/cg-sandbox
+cd gopath/src/github.com/18F/purge-sandboxes
 
 cd cmd/purge
 

--- a/ci/purge.yml
+++ b/ci/purge.yml
@@ -9,10 +9,10 @@ image_resource:
 
 inputs:
 - name: sandbox-source
-  path: gopath/src/github.com/18F/purge-sandboxes
+  path: gopath/src/github.com/cloud-gov/purge-sandboxes
 
 run:
-  path: gopath/src/github.com/18F/purge-sandboxes/ci/purge.sh
+  path: gopath/src/github.com/cloud-gov/purge-sandboxes/ci/purge.sh
 
 params:
   API_ADDRESS:

--- a/ci/purge.yml
+++ b/ci/purge.yml
@@ -9,10 +9,10 @@ image_resource:
 
 inputs:
 - name: sandbox-source
-  path: gopath/src/github.com/18F/cg-sandbox
+  path: gopath/src/github.com/18F/purge-sandboxes
 
 run:
-  path: gopath/src/github.com/18F/cg-sandbox/ci/purge.sh
+  path: gopath/src/github.com/18F/purge-sandboxes/ci/purge.sh
 
 params:
   API_ADDRESS:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-cd cg-sandbox
+cd purge-sandboxes
 
 go test ./...

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -9,7 +9,7 @@ image_resource:
 
 inputs:
 - name: sandbox-source
-  path: cg-sandbox
+  path: purge-sandboxes
 
 run:
-  path: cg-sandbox/ci/test.sh
+  path: purge-sandboxes/ci/test.sh

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -1,4 +1,4 @@
-sandbox-config-uri: https://github.com/18F/cg-sandbox
+sandbox-config-uri: https://github.com/18F/purge-sandboxes
 sandbox-config-branch: master
 
 notify-api-url:

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -1,4 +1,4 @@
-sandbox-config-uri: https://github.com/18F/purge-sandboxes
+sandbox-config-uri: https://github.com/cloud-gov/purge-sandboxes
 sandbox-config-branch: master
 
 notify-api-url:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/18f/cg-sandbox
+module github.com/18f/purge-sandboxes
 
 go 1.22
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/18f/purge-sandboxes
+module github.com/cloud-gov/purge-sandboxes
 
 go 1.22
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates repo name from `cg-sandbox` to `purge-sandboxes`, which was also done manually in GitHub. The name `cg-sandbox` was not descriptive at all of the purpose of this repo, while `purge-sandboxes` clearly identifies what this code is intended to do
- [rename Go module from github.com/18F/purge-sandboxes to github.com/cloud-gov/puge-sandboxes](https://github.com/cloud-gov/purge-sandboxes/commit/b9ca5e2dae6df8cf6d991a4225b3b796c823448b) since `cloud-gov` and not `18F` is the owner of this code

## security considerations

None, just renaming repo and Go module for clarity and consistency
