### PR TITLE
remove image reference in task files

### DIFF
--- a/ci/purge.yml
+++ b/ci/purge.yml
@@ -1,12 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: golang
-    tag: "1.13"
-
 inputs:
 - name: sandbox-source
   path: gopath/src/github.com/cloud-gov/purge-sandboxes

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -1,12 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: golang
-    tag: "1.13"
-
 inputs:
 - name: sandbox-source
   path: purge-sandboxes


### PR DESCRIPTION
## Changes proposed in this pull request:
- These tasks are set to run using the general-task image in the pipeline file, so we can remove these docker-image references

## security considerations
Making sure the pipeline is using hardened images
